### PR TITLE
Fix types in isinstance functions

### DIFF
--- a/spyndex/spyndex.py
+++ b/spyndex/spyndex.py
@@ -227,20 +227,20 @@ def computeIndex(
         if returnOrigin:
             if isinstance(result[0], np.ndarray):
                 result = np.array(result)
-            elif isinstance(result[0], pd.core.series.Series):
+            elif isinstance(result[0], pd.Series):
                 result = pd.DataFrame(dict(zip(index, result)))
-            elif isinstance(result[0], xr.core.dataarray.DataArray):
+            elif isinstance(result[0], xr.DataArray):
                 result = [x.reset_coords(drop=True) for x in result]
                 result = xr.concat(result, dim=coordinate).assign_coords(
                     {coordinate: index}
                 )
-            elif isinstance(result[0], ee.image.Image):
+            elif isinstance(result[0], ee.Image):
                 result = ee.Image(result).rename(index)
-            elif isinstance(result[0], ee.ee_number.Number):
+            elif isinstance(result[0], ee.Number):
                 result = ee.List(result)
-            elif isinstance(result[0], dask.array.core.Array):
+            elif isinstance(result[0], dask.array.Array):
                 result = da.array(result)
-            elif isinstance(result[0], dask.dataframe.core.Series):
+            elif isinstance(result[0], dask.dataframe.Series):
                 result = dd.concat(result, axis="columns")
                 result.columns = index
 
@@ -402,10 +402,10 @@ def computeKernel(kernel: str, params: Optional[dict] = None, **kwargs) -> Any:
     }
 
     if (
-        isinstance(params["a"], ee.image.Image)
-        or isinstance(params["b"], ee.image.Image)
-        or isinstance(params["a"], ee.ee_number.Number)
-        or isinstance(params["b"], ee.ee_number.Number)
+        isinstance(params["a"], ee.Image)
+        or isinstance(params["b"], ee.Image)
+        or isinstance(params["a"], ee.Number)
+        or isinstance(params["b"], ee.Number)
     ):
         kernels["RBF"] = "exp((-1.0 * (a - b) ** 2.0)/(2.0 * sigma ** 2.0))"
         result = params["a"].expression(kernels[kernel], params)

--- a/tests/test_spyndex.py
+++ b/tests/test_spyndex.py
@@ -172,7 +172,7 @@ class Test(unittest.TestCase):
                 "g": spyndex.constants.g.default,
             },
         )
-        self.assertIsInstance(result, pd.core.frame.DataFrame)
+        self.assertIsInstance(result, pd.DataFrame)
 
     def test_pandas_origin_false(self):
         """Test the computeIndex() method"""
@@ -191,7 +191,7 @@ class Test(unittest.TestCase):
             returnOrigin=False,
         )
         self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], pd.core.series.Series)
+        self.assertIsInstance(result[0], pd.Series)
 
     def test_xarray(self):
         """Test the computeIndex() method"""
@@ -208,7 +208,7 @@ class Test(unittest.TestCase):
                 "g": spyndex.constants.g.default,
             },
         )
-        self.assertIsInstance(result, xr.core.dataarray.DataArray)
+        self.assertIsInstance(result, xr.DataArray)
 
     def test_xarray_origin_false(self):
         """Test the computeIndex() method"""
@@ -227,7 +227,7 @@ class Test(unittest.TestCase):
             returnOrigin=False,
         )
         self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], xr.core.dataarray.DataArray)
+        self.assertIsInstance(result[0], xr.DataArray)
 
     def test_ee(self):
         """Test the computeIndex() method"""
@@ -244,7 +244,7 @@ class Test(unittest.TestCase):
                 "g": spyndex.constants.g.default,
             },
         )
-        self.assertIsInstance(result, ee.image.Image)
+        self.assertIsInstance(result, ee.Image)
 
     def test_ee_origin_false(self):
         """Test the computeIndex() method"""
@@ -263,7 +263,7 @@ class Test(unittest.TestCase):
             returnOrigin=False,
         )
         self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], ee.image.Image)
+        self.assertIsInstance(result[0], ee.Image)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When I tried to run tests, some of them crashed with error 
```
FAILED tests/test_spyndex.py::Test::test_numeric - AttributeError: module 'dask.dataframe.core' has no attribute 'Series'
FAILED tests/test_spyndex.py::Test::test_numeric_kwargs - AttributeError: module 'dask.dataframe.core' has no attribute 'Series'
FAILED tests/test_spyndex.py::Test::test_numeric_online - AttributeError: module 'dask.dataframe.core' has no attribute 'Series'
```

Looks like `Series` is no longer in `dask.dataframe.core`.

Now trying to import `dask.dataframe.Series` shows `<class 'dask.dataframe.dask_expr._collection.Series'>`.

Maybe it would be better to switch to using types available via public API (like `pd.Series` instead of `pd.core.series.Series` etc.), because they are less likely to be moved somewhere else someday.