### PR TITLE
Add `dtype` parameter to `computeIndex`, `computeKernel`, and `SpectralIndex.compute`

### DIFF
--- a/docs/tutorials/numpy.ipynb
+++ b/docs/tutorials/numpy.ipynb
@@ -945,6 +945,104 @@
     "\n",
     "Wonderfuuul!"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlling output precision with `dtype`\n",
+    "\n",
+    "As we just saw, `spyndex` respects the dtype of your inputs. But things get tricky when you start from integer bands, e.g. `numpy.uint16` reflectance values as you would typically get from a raw satellite product. Scaling such a band to reflectance (dividing by, say, 10000) already upcasts it to `float64`, since true division of a NumPy integer array always produces `float64`, *before* any index formula or `float` constant is even involved. Let's see it in action:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B = (np.random.normal(0.13,0.05,(100,100)) * 10000).astype(\"uint16\")\n",
+    "G = (np.random.normal(0.23,0.06,(100,100)) * 10000).astype(\"uint16\")\n",
+    "R = (np.random.normal(0.14,0.07,(100,100)) * 10000).astype(\"uint16\")\n",
+    "N = (np.random.normal(0.60,0.10,(100,100)) * 10000).astype(\"uint16\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's scale the bands to reflectance and compute a couple of indices, `NDVI` and `EVI`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameters = {\n",
+    "    \"N\": N / 10000,\n",
+    "    \"R\": R / 10000,\n",
+    "    \"B\": B / 10000,\n",
+    "    \"g\": spyndex.constants.g.default,\n",
+    "    \"C1\": spyndex.constants.C1.default,\n",
+    "    \"C2\": spyndex.constants.C2.default,\n",
+    "    \"L\": 1.0,\n",
+    "}\n",
+    "\n",
+    "idx = spyndex.computeIndex([\"NDVI\",\"EVI\"], parameters)\n",
+    "print(f\"idx dtype: {idx.dtype}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`idx dtype: float64`! Even though our original bands were `uint16`, dividing them by `10000` to scale to reflectance already produced `float64` arrays (that's just how NumPy's true division works on integer arrays), and that `float64`-ness then propagates through the whole computation and might blow up your memory usage.\n",
+    "\n",
+    "The usual workaround is to manually cast every band to `float32` before calling `computeIndex()`:\n",
+    "\n",
+    "```python\n",
+    "parameters = {\n",
+    "    \"N\": (N / 10000).astype(\"float32\"),\n",
+    "    \"R\": (R / 10000).astype(\"float32\"),\n",
+    "    \"B\": (B / 10000).astype(\"float32\"),\n",
+    "    \"g\": spyndex.constants.g.default,\n",
+    "    \"C1\": spyndex.constants.C1.default,\n",
+    "    \"C2\": spyndex.constants.C2.default,\n",
+    "    \"L\": 1.0,\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "which works, but is verbose and easy to forget (e.g. leaving one of the bands as `uint16` would silently upcast everything to `float64` again). Instead, `spyndex.computeIndex()` (and `spyndex.computeKernel()` and `SpectralIndex.compute()`) accept a `dtype` parameter, which casts every value in `params` for you before the index formula is evaluated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameters = {\n",
+    "    \"N\": N / 10000,\n",
+    "    \"R\": R / 10000,\n",
+    "    \"B\": B / 10000,\n",
+    "    \"g\": spyndex.constants.g.default,\n",
+    "    \"C1\": spyndex.constants.C1.default,\n",
+    "    \"C2\": spyndex.constants.C2.default,\n",
+    "    \"L\": 1.0,\n",
+    "}\n",
+    "\n",
+    "idx = spyndex.computeIndex([\"NDVI\",\"EVI\"], parameters, dtype=\"float32\")\n",
+    "print(f\"idx dtype: {idx.dtype}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now `idx dtype: float32`, without the need to manually cast every parameter beforehand! Note that values that don't support casting (e.g. Earth Engine objects) are left untouched when `dtype` is used, since Earth Engine manages numeric precision through its own API."
+   ]
   }
  ],
  "metadata": {

--- a/spyndex/axioms.py
+++ b/spyndex/axioms.py
@@ -128,7 +128,7 @@ class SpectralIndex(object):
             :code:`float` constants. Values that don't support casting (e.g. Earth
             Engine objects) are left untouched.
 
-            .. versionadded:: 0.13.0
+            .. versionadded:: 0.12.1
         kwargs:
             Parameters used as inputs for the computation as keyword pairs. Ignored when
             params is defined.

--- a/spyndex/axioms.py
+++ b/spyndex/axioms.py
@@ -111,7 +111,7 @@ class SpectralIndex(object):
 
         return result
 
-    def compute(self, params=None, **kwargs):
+    def compute(self, params=None, dtype=None, **kwargs):
         """Computes a Spectral Index.
 
         Parameters
@@ -121,6 +121,14 @@ class SpectralIndex(object):
             compatible with Overloaded Operators. Some inputs' types supported are pandas
             series, numpy arrays, xarray objects and numeric objects. Earth Engine objects
             are also compatible when using eemont.
+        dtype : str, default = None
+            Data type to cast :code:`params` to before computing the index (e.g.
+            :code:`"float32"`). Useful to avoid the automatic upcasting to
+            :code:`float64` that occurs when mixing numeric arrays with Python
+            :code:`float` constants. Values that don't support casting (e.g. Earth
+            Engine objects) are left untouched.
+
+            .. versionadded:: 0.13.0
         kwargs:
             Parameters used as inputs for the computation as keyword pairs. Ignored when
             params is defined.
@@ -154,7 +162,7 @@ class SpectralIndex(object):
         else:
             parameters = params
 
-        return computeIndex(self.short_name, parameters)
+        return computeIndex(self.short_name, parameters, dtype=dtype)
 
 
 def _create_indices():

--- a/spyndex/spyndex.py
+++ b/spyndex/spyndex.py
@@ -3,6 +3,7 @@ import sys
 from typing import Any, List, Optional, Union
 
 from .utils import (
+    _cast_params,
     _check_params,
     _get_indices,
     _has_ee_image,
@@ -18,6 +19,7 @@ def computeIndex(
     online: bool = False,
     returnOrigin: bool = True,
     coordinate: str = "index",
+    dtype: Optional[str] = None,
     **kwargs,
 ) -> Any:
     """Computes one or more Spectral Indices from the Awesome Spectral Indices list.
@@ -49,6 +51,14 @@ def computeIndex(
     coordinate : str, default = "index"
         Name of the coordinate used to concatenate :code:`xarray.DataArray` objects when
         :code:`returnOrigin = True`.
+    dtype : str, default = None
+        Data type to cast :code:`params` to before computing the index (e.g.
+        :code:`"float32"`). Useful to avoid the automatic upcasting to
+        :code:`float64` that occurs when mixing numeric arrays (e.g. :code:`uint16`
+        or :code:`float32`) with Python :code:`float` constants. Values that don't
+        support casting (e.g. Earth Engine objects) are left untouched.
+
+        .. versionadded:: 0.13.0
     kwargs:
         Parameters used as inputs for the computation as keyword pairs. Ignored when
         params is defined.
@@ -201,10 +211,30 @@ def computeIndex(
     ...         "L": 0.5
     ...     }
     ... ).compute()
+
+    To avoid the automatic upcasting to :code:`float64` when working with
+    :code:`uint16` or :code:`float32` bands, use the :code:`dtype` parameter:
+
+    >>> s2_gm_indices = spyndex.computeIndex(
+    ...     index = ["NDVI", "EVI", "SAVI", "NIRv"],
+    ...     params = {
+    ...         "N": s2_gm.B08 / 10000,
+    ...         "R": s2_gm.B04 / 10000,
+    ...         "B": s2_gm.B02 / 10000,
+    ...         "g": spyndex.constants.g.default,
+    ...         "C1": spyndex.constants.C1.default,
+    ...         "C2": spyndex.constants.C2.default,
+    ...         "L": 1.0,
+    ...     },
+    ...     dtype = "float32",
+    ... )
     """
 
     if params is None:
         params = kwargs
+
+    if dtype is not None:
+        params = _cast_params(params, dtype)
 
     if not isinstance(index, list):
         index = [index]
@@ -256,7 +286,12 @@ def computeIndex(
     return result
 
 
-def computeKernel(kernel: str, params: Optional[dict] = None, **kwargs) -> Any:
+def computeKernel(
+    kernel: str,
+    params: Optional[dict] = None,
+    dtype: Optional[str] = None,
+    **kwargs,
+) -> Any:
     """Computes a kernel :code:`k(a,b)`.
 
     Kernel parameters are used for kernel indices like the kNDVI that requires the
@@ -273,6 +308,13 @@ def computeKernel(kernel: str, params: Optional[dict] = None, **kwargs) -> Any:
         and 'sigma' (length-scale) must be declared. For :code:`kernel = 'poly'`, the
         parameters 'a' (band A), 'b' (band B), 'p' (kernel degree) and 'c' (trade-off)
         must be declared.
+    dtype : str, default = None
+        Data type to cast :code:`params` to before computing the kernel (e.g.
+        :code:`"float32"`). Values that don't support casting (e.g. Earth Engine
+        objects) are left untouched, since Earth Engine dtype is handled through
+        its own API.
+
+        .. versionadded:: 0.13.0
     kwargs:
         Parameters used as inputs for the computation as keyword pairs. Ignored when
         params is defined.
@@ -404,6 +446,9 @@ def computeKernel(kernel: str, params: Optional[dict] = None, **kwargs) -> Any:
 
     if params is None:
         params = kwargs
+
+    if dtype is not None:
+        params = _cast_params(params, dtype)
 
     kernels = {
         "linear": "a * b",

--- a/spyndex/spyndex.py
+++ b/spyndex/spyndex.py
@@ -58,7 +58,7 @@ def computeIndex(
         or :code:`float32`) with Python :code:`float` constants. Values that don't
         support casting (e.g. Earth Engine objects) are left untouched.
 
-        .. versionadded:: 0.13.0
+        .. versionadded:: 0.12.1
     kwargs:
         Parameters used as inputs for the computation as keyword pairs. Ignored when
         params is defined.
@@ -314,7 +314,7 @@ def computeKernel(
         objects) are left untouched, since Earth Engine dtype is handled through
         its own API.
 
-        .. versionadded:: 0.13.0
+        .. versionadded:: 0.12.1
     kwargs:
         Parameters used as inputs for the computation as keyword pairs. Ignored when
         params is defined.

--- a/spyndex/spyndex.py
+++ b/spyndex/spyndex.py
@@ -212,22 +212,39 @@ def computeIndex(
     ...     }
     ... ).compute()
 
-    To avoid the automatic upcasting to :code:`float64` when working with
-    :code:`uint16` or :code:`float32` bands, use the :code:`dtype` parameter:
+    Raw satellite products are often stored as scaled integers (e.g.
+    :code:`uint16`), which get upcast to :code:`float64` as soon as they are
+    scaled to reflectance, even if that's not what you want. Let's check:
 
-    >>> s2_gm_indices = spyndex.computeIndex(
-    ...     index = ["NDVI", "EVI", "SAVI", "NIRv"],
+    >>> R = (np.random.normal(0.12, 0.05, 10000) * 10000).astype("uint16")
+    >>> N = (np.random.normal(0.67, 0.11, 10000) * 10000).astype("uint16")
+    >>> ndvi = spyndex.computeIndex(
+    ...     index = "NDVI",
     ...     params = {
-    ...         "N": s2_gm.B08 / 10000,
-    ...         "R": s2_gm.B04 / 10000,
-    ...         "B": s2_gm.B02 / 10000,
-    ...         "g": spyndex.constants.g.default,
-    ...         "C1": spyndex.constants.C1.default,
-    ...         "C2": spyndex.constants.C2.default,
-    ...         "L": 1.0,
-    ...     },
-    ...     dtype = "float32",
+    ...         "N": N / 10000,
+    ...         "R": R / 10000
+    ...     }
     ... )
+    >>> ndvi
+    array([0.78067101, 0.5782938 , 0.62262558, ..., 0.68524269, 0.68087385, 
+           0.6166534 ], shape=(10000,))
+    >>> ndvi.dtype
+    dtype('float64')
+
+    The result is a :code:`float64` array. Use the :code:`dtype` parameter to
+    cast the :code:`params` to :code:`float32` before the computation and avoid
+    the unwanted upcasting:
+
+    >>> spyndex.computeIndex(
+    ...     index = "NDVI",
+    ...     params = {
+    ...         "N": N / 10000,
+    ...         "R": R / 10000
+    ...     },
+    ...     dtype = "float32"
+    ... )
+    array([0.780671  , 0.57829386, 0.6226255 , ..., 0.6852427 , 
+           0.6808739 , 0.6166534 ], shape=(10000,), dtype=float32)
     """
 
     if params is None:

--- a/spyndex/utils.py
+++ b/spyndex/utils.py
@@ -74,6 +74,45 @@ def _check_params(index: str, params: dict, indices: dict):
             )
 
 
+def _cast_params(params: dict, dtype) -> dict:
+    """Casts the numeric values of a parameters dictionary to a given dtype.
+
+    Values that support :code:`.astype()` (e.g. numpy arrays, pandas Series,
+    xarray DataArrays and dask arrays/series) are cast directly. Plain Python
+    :code:`int`/:code:`float` scalars are cast via :code:`numpy.dtype.type()`.
+    Any other value (e.g. Earth Engine objects) is left untouched, since Earth
+    Engine manages numeric precision through its own API.
+
+    Parameters
+    ----------
+    params : dict
+        Parameters dictionary to cast.
+    dtype : str | type | numpy.dtype
+        Target dtype (anything accepted by :code:`numpy.dtype()`, e.g.
+        :code:`"float32"` or :code:`numpy.float32`).
+
+    Returns
+    -------
+    dict
+        A new dictionary with the same keys as :code:`params`, with values cast
+        to :code:`dtype` where applicable. The original dictionary is not
+        modified.
+    """
+    np = _import_optional_dependency("numpy")
+    np_dtype = np.dtype(dtype)
+
+    cast = {}
+    for key, value in params.items():
+        if hasattr(value, "astype"):
+            cast[key] = value.astype(np_dtype)
+        elif isinstance(value, (int, float)):
+            cast[key] = np_dtype.type(value)
+        else:
+            cast[key] = value
+
+    return cast
+
+
 def _import_optional_dependency(module: str, extra: str = None):
     """Import an optional dependency or explain which spyndex extra provides it."""
     if extra is None:

--- a/tests/test_spyndex.py
+++ b/tests/test_spyndex.py
@@ -275,5 +275,127 @@ class Test(unittest.TestCase):
         self.assertIsInstance(result[0], ee.Image)
 
 
+    def test_dtype_numeric(self):
+        """Test the dtype parameter with numeric inputs"""
+        result = spyndex.computeIndex(
+            "NDVI",
+            {
+                "N": 0.6,
+                "R": 0.1,
+            },
+            dtype="float32",
+        )
+        self.assertIsInstance(result, np.float32)
+
+    def test_dtype_numpy(self):
+        """Test the dtype parameter with numpy arrays"""
+        N_uint16 = (N * 10000).astype("uint16")
+        R_uint16 = (R * 10000).astype("uint16")
+
+        result_default = spyndex.computeIndex(
+            "NDVI",
+            {
+                "N": N_uint16 / 10000,
+                "R": R_uint16 / 10000,
+            },
+        )
+        self.assertEqual(result_default.dtype, np.float64)
+
+        result_cast = spyndex.computeIndex(
+            "NDVI",
+            {
+                "N": N_uint16 / 10000,
+                "R": R_uint16 / 10000,
+            },
+            dtype="float32",
+        )
+        self.assertEqual(result_cast.dtype, np.float32)
+
+    def test_dtype_numpy_multiple(self):
+        """Test the dtype parameter with numpy arrays and multiple indices"""
+        result = spyndex.computeIndex(
+            indices,
+            {
+                "N": N,
+                "R": R,
+                "G": G,
+                "B": B,
+                "L": spyndex.constants.L.default,
+                "C1": spyndex.constants.C1.default,
+                "C2": spyndex.constants.C2.default,
+                "g": spyndex.constants.g.default,
+            },
+            dtype="float32",
+        )
+        self.assertIsInstance(result, np.ndarray)
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_dtype_pandas(self):
+        """Test the dtype parameter with pandas Series"""
+        result = spyndex.computeIndex(
+            "NDVI",
+            {
+                "N": df["N"],
+                "R": df["R"],
+            },
+            dtype="float32",
+        )
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_dtype_xarray(self):
+        """Test the dtype parameter with xarray DataArrays"""
+        result = spyndex.computeIndex(
+            "NDVI",
+            {
+                "N": da.sel(channel="N"),
+                "R": da.sel(channel="R"),
+            },
+            dtype="float32",
+        )
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_dtype_class(self):
+        """Test the dtype parameter through SpectralIndex.compute()"""
+        result = spyndex.indices.NDVI.compute(
+            {
+                "N": 0.6,
+                "R": 0.1,
+            },
+            dtype="float32",
+        )
+        self.assertIsInstance(result, np.float32)
+
+    def test_dtype_kernel(self):
+        """Test the dtype parameter through computeKernel()"""
+        result = spyndex.computeKernel(
+            "linear",
+            {
+                "a": N,
+                "b": R,
+            },
+            dtype="float32",
+        )
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_dtype_invalid(self):
+        """Test that an invalid dtype raises an exception"""
+        with self.assertRaises(TypeError):
+            spyndex.computeIndex(
+                "NDVI",
+                {
+                    "N": 0.6,
+                    "R": 0.1,
+                },
+                dtype="not_a_dtype",
+            )
+
+    def test_dtype_does_not_mutate_params(self):
+        """Test that the original params dict is not mutated"""
+        params = {"N": N, "R": R}
+        spyndex.computeIndex("NDVI", params, dtype="float32")
+        self.assertEqual(params["N"].dtype, np.float64)
+        self.assertEqual(params["R"].dtype, np.float64)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi @davemlz! 

I've had this on my mind for a while. I think currently it is quite easy to accidentally create `float64` arrays even though the user might not have intended to do so and then wonders why the process is slow and memory usage exploding (happend to some students of mine... and myself) 😅  

So this PR adds an optional `dtype` parameter to `computeIndex()`, `computeKernel()`, and `SpectralIndex.compute()`. When provided, all values in `params` are cast to the requested dtype before the index/kernel formula is evaluated, avoiding the implicit upcast to `float64` that otherwise occurs when mixing typed arrays (e.g. `uint16` or `float32`) with Python `float` constants.

Changes:
- Added a `_cast_params()` helper in `spyndex/utils.py` that casts numeric/array-like values (anything supporting `.astype()`: NumPy, pandas, xarray, Dask) and plain Python `int`/`float` scalars to the given dtype, returning a new dict without mutating the caller's `params`. Values without `.astype()` (e.g. Earth Engine objects) are left untouched.
- Added the `dtype` parameter to `computeIndex()` and `computeKernel()` in `spyndex/spyndex.py`, and to `SpectralIndex.compute()` in `spyndex/axioms.py`.
- Added a few tests
- Added a example in numpy tutorial

All existing and new tests pass locally (23 passed, 2 skipped due to no local Earth Engine installation).

Let me know what you think, if I missed something or if this change is not wanted. 